### PR TITLE
Fix arqc

### DIFF
--- a/payshield.js
+++ b/payshield.js
@@ -191,7 +191,7 @@ PayshieldCodec.prototype.decode = function(buff, $meta) {
         }
         bodyObj.type = 'payshield.' + bodyObj.errorCode;
         bodyObj.errorCode = 'payshield.' + bodyObj.errorCode;
-        bodyObj.errorMessage = ERRORCODES[bodyObj.errorCode];
+        bodyObj.errorMessage = cmd.method + ':' + (ERRORCODES[bodyObj.errorCode] || bodyObj.errorCode);
     }
     return bodyObj;
 };

--- a/payshield.js
+++ b/payshield.js
@@ -109,6 +109,7 @@ PayshieldCodec.prototype.init = function(config) {
         this.log.info('Initializing Payshield parser! headerFormat: ' + config.headerFormat + ',messageFormat:' + config.messageFormat);
     }
     this.headerPattern = bitsyntax.parse('headerNo:' + config.headerFormat + ', code:2/string, body/binary');
+    this.errorPattern = bitsyntax.parse('errorCode:2/string, rest/binary');
 
     var commandsObj = merge({}, defaultFormat, config.messageFormat);
 
@@ -138,6 +139,7 @@ PayshieldCodec.prototype.init = function(config) {
                 }
                 this.commands[property + ':response'] = {
                     pattern: responsePattern,
+                    errorPattern: commandsObj[property].errorPattern && bitsyntax.parse(commandsObj[property].errorPattern),
                     code: commandsObj[property].responseCode,
                     method: property,
                     mtid: 'response'
@@ -166,14 +168,13 @@ PayshieldCodec.prototype.decode = function(buff, $meta) {
         throw new Error('Not implemented opcode:' + commandName + '!');
     }
 
-    var bodyObj = bitsyntax.match(bitsyntax.parse('errorCode:2/string, rest/binary'), headObj.body);
+    var bodyObj = bitsyntax.match(this.errorPattern, headObj.body);
     if (!bodyObj) {
         throw new Error('Unable to match response errorCode!');
     }
     // 00 = No error
-    // 01 = Verification failure or warning of imported key parity error (in some cases is warning)
     // 02 = Key inappropriate length for algorithm (in some cases is warning)
-    if (['00', '01', '02'].includes(bodyObj.errorCode)) {
+    if (['00', '02'].includes(bodyObj.errorCode)) {
         bodyObj = bitsyntax.match(cmd.pattern, headObj.body);
         if (!bodyObj) {
             throw new Error('Unable to match pattern for opcode:' + commandName + '!');
@@ -185,10 +186,12 @@ PayshieldCodec.prototype.decode = function(buff, $meta) {
         $meta.trace = headObj.headerNo;
         $meta.mtid = 'error';
         $meta.method = cmd.method;
-        bodyObj = {
-            errorCode: 'payshield.' + bodyObj.errorCode,
-            errorMessage: ERRORCODES[bodyObj.errorCode]
-        };
+        if (cmd.errorPattern) { // try to match errorPattern if it exists
+            bodyObj = bitsyntax.match(cmd.errorPattern, headObj.body) || bodyObj;
+        }
+        bodyObj.type = 'payshield.' + bodyObj.errorCode;
+        bodyObj.errorCode = 'payshield.' + bodyObj.errorCode;
+        bodyObj.errorMessage = ERRORCODES[bodyObj.errorCode];
     }
     return bodyObj;
 };

--- a/payshield.messages.json
+++ b/payshield.messages.json
@@ -39,17 +39,19 @@
         "requestPattern": "cvk:33/string, account:12/string, \";\", expirationDate:4/string, serviceCode:3/string",
         "responsePattern": "errorCode:2/string, cvv:3/string"
     },
-    "generateArqcKW": {
+    "generateArqc4": {
         "requestCode": "KW",
         "responseCode": "KX",
         "requestPattern": "modeFlag:1/string, schemeId:1/string, mkac:33/string, ivac:ivacLength/string-binhex, panLength:panLengthLength/string, panSeqNo:panSeqNoLength/string-binhex, delimiter1:delimiter1Length/string, branchHeightParams:branchHeightParamsLength/string, atc:2/string-binhex, transactionDataLengthHex:transactionDataLengthLength/string, transactionData:transactionDataLengthDec/string-binhex, delimiter2:delimiter2Length/string, arqc:8/string-binhex, arc:arcLength/string-binhex, csu:csuLength/string-binhex, padLength:padLengthLength/string, pad:padLength/string-binhex",
-        "responsePattern": "errorCode:2/string, responseData/binary"
+        "responsePattern": "errorCode:2/string, arpc/binary",
+        "errorPattern": "errorCode:2/string, diagnosticData:8/string-binhex"
     },
-    "generateArqcKQ": {
+    "generateArqc3": {
         "requestCode": "KQ",
         "responseCode": "KR",
         "requestPattern": "modeFlag:1/string, schemeId:1/string, mkac:33/string, panSeqNo:8/string-binhex, atc:2/string-binhex, unpredictableNumber:4/string-binhex, transactionDataLengthHex:transactionDataLengthLength/string, transactionData:transactionDataLengthDec/string-binhex, delimiter:delimiterLength/string, arqc:8/string-binhex, arc:arcLength/string-binhex",
-        "responsePattern": "errorCode:2/string, responseData/binary"
+        "responsePattern": "errorCode:2/string, arpc/binary",
+        "errorPattern": "errorCode:2/string, diagnosticData:8/string-binhex"
     },
     "verifyMac": {
         "requestCode": "M8",


### PR DESCRIPTION
Improve naming and parsing of arqc commands.
Error 01 is not really a warning. It should be up to the caller to decide if 01 is tolerated, the default is to treat this as error.

Errors messages will now also return the command that was invoked, for easier discovery what exactly failed.